### PR TITLE
[BE] feat: 방 신청 구현(#32)

### DIFF
--- a/backend/src/main/java/corea/WebConfig.java
+++ b/backend/src/main/java/corea/WebConfig.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
     @Override
@@ -22,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3000);
     }
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);

--- a/backend/src/main/java/corea/WebConfig.java
+++ b/backend/src/main/java/corea/WebConfig.java
@@ -1,11 +1,18 @@
 package corea;
 
+import corea.auth.resolver.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -14,5 +21,9 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "DELETE")
                 .allowCredentials(true)
                 .maxAge(3000);
+    }
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/backend/src/main/java/corea/auth/RequestHandler.java
+++ b/backend/src/main/java/corea/auth/RequestHandler.java
@@ -5,9 +5,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class RequestHandler {
+
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    public String extract(HttpServletRequest request){
+
+    public String extract(HttpServletRequest request) {
         return request.getHeader(AUTHORIZATION_HEADER);
     }
-
 }

--- a/backend/src/main/java/corea/auth/RequestHandler.java
+++ b/backend/src/main/java/corea/auth/RequestHandler.java
@@ -1,0 +1,13 @@
+package corea.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequestHandler {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    public String extract(HttpServletRequest request){
+        return request.getHeader(AUTHORIZATION_HEADER);
+    }
+
+}

--- a/backend/src/main/java/corea/auth/annotation/LoginUser.java
+++ b/backend/src/main/java/corea/auth/annotation/LoginUser.java
@@ -1,0 +1,14 @@
+package corea.auth.annotation;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Hidden()
+public @interface LoginUser {
+}

--- a/backend/src/main/java/corea/auth/domain/AuthInfo.java
+++ b/backend/src/main/java/corea/auth/domain/AuthInfo.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Getter
 public class AuthInfo {
+
     private final Long id;
 
     private final String name;

--- a/backend/src/main/java/corea/auth/domain/AuthInfo.java
+++ b/backend/src/main/java/corea/auth/domain/AuthInfo.java
@@ -1,0 +1,33 @@
+package corea.auth.domain;
+
+import corea.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Getter
+public class AuthInfo {
+    private final Long id;
+
+    private final String name;
+
+    private final String email;
+
+    public static AuthInfo from(Member member){
+        return new AuthInfo(member.getId(), member.getUserName(), member.getEmail());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AuthInfo authInfo)) return false;
+        return Objects.equals(id, authInfo.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/backend/src/main/java/corea/auth/resolver/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/corea/auth/resolver/LoginMemberArgumentResolver.java
@@ -19,6 +19,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 @RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
     private final RequestHandler requestHandler;
     private final MemberRepository memberRepository;
 
@@ -32,7 +33,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
                                     ModelAndViewContainer mavContainer,
                                     NativeWebRequest webRequest,
                                     WebDataBinderFactory binderFactory) {
-
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         Member member = memberRepository.findByEmail(requestHandler.extract(request))
                 .orElseThrow(()-> new CoreaException(ExceptionType.AUTHORIZATION_ERROR));

--- a/backend/src/main/java/corea/auth/resolver/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/corea/auth/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,41 @@
+package corea.auth.resolver;
+
+import corea.auth.RequestHandler;
+import corea.auth.annotation.LoginUser;
+import corea.auth.domain.AuthInfo;
+import corea.exception.CoreaException;
+import corea.exception.ExceptionType;
+import corea.member.domain.Member;
+import corea.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final RequestHandler requestHandler;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class);
+    }
+
+    @Override
+    public AuthInfo resolveArgument(MethodParameter parameter,
+                                    ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest,
+                                    WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Member member = memberRepository.findByEmail(requestHandler.extract(request))
+                .orElseThrow(()-> new CoreaException(ExceptionType.AUTHORIZATION_ERROR));
+        return AuthInfo.from(member);
+    }
+}

--- a/backend/src/main/java/corea/exception/CoreaException.java
+++ b/backend/src/main/java/corea/exception/CoreaException.java
@@ -1,9 +1,16 @@
 package corea.exception;
 
-public class CoreaException extends Exception {
-    private final ExceptionType exceptionType;
+import org.springframework.http.HttpStatus;
 
-    public CoreaException(ExceptionType exceptionType) {
+public class CoreaException extends RuntimeException {
+    private final ExceptionType exceptionType;
+    public CoreaException(ExceptionType exceptionType){
+        super(exceptionType.getMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public CoreaException(ExceptionType exceptionType,String message) {
+        super(message);
         this.exceptionType = exceptionType;
     }
 
@@ -12,7 +19,13 @@ public class CoreaException extends Exception {
         this.exceptionType = exceptionType;
     }
 
-    public ExceptionType getExceptionType() {
-        return exceptionType;
+    public HttpStatus getHttpStatus(){
+        return exceptionType.getHttpStatus();
     }
+    
+    @Override
+    public String getMessage(){
+        return exceptionType.getMessage();
+    }
+
 }

--- a/backend/src/main/java/corea/exception/CoreaException.java
+++ b/backend/src/main/java/corea/exception/CoreaException.java
@@ -3,13 +3,15 @@ package corea.exception;
 import org.springframework.http.HttpStatus;
 
 public class CoreaException extends RuntimeException {
+
     private final ExceptionType exceptionType;
-    public CoreaException(ExceptionType exceptionType){
+
+    public CoreaException(ExceptionType exceptionType) {
         super(exceptionType.getMessage());
         this.exceptionType = exceptionType;
     }
 
-    public CoreaException(ExceptionType exceptionType,String message) {
+    public CoreaException(ExceptionType exceptionType, String message) {
         super(message);
         this.exceptionType = exceptionType;
     }
@@ -19,13 +21,12 @@ public class CoreaException extends RuntimeException {
         this.exceptionType = exceptionType;
     }
 
-    public HttpStatus getHttpStatus(){
+    public HttpStatus getHttpStatus() {
         return exceptionType.getHttpStatus();
     }
-    
+
     @Override
-    public String getMessage(){
+    public String getMessage() {
         return exceptionType.getMessage();
     }
-
 }

--- a/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
+++ b/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
@@ -11,7 +11,7 @@ public class ExceptionResponseHandler {
 
     @ExceptionHandler(CoreaException.class)
     public ResponseEntity<ErrorResponse> handleCoreaException(final CoreaException e) {
-        log.debug("Reaction Game exception [statusCode = {}, errorMessage = {}, cause = {}]", e.getHttpStatus(), e.getMessage(),e.getCause());
+        log.debug("Corea exception [statusCode = {}, errorMessage = {}, cause = {}]", e.getHttpStatus(), e.getMessage(),e.getCause());
         return ResponseEntity.status(e.getHttpStatus())
                 .body(new ErrorResponse(e.getMessage()));
     }

--- a/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
+++ b/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
@@ -11,13 +11,14 @@ public class ExceptionResponseHandler {
 
     @ExceptionHandler(CoreaException.class)
     public ResponseEntity<ErrorResponse> handleCoreaException(final CoreaException e) {
-        log.debug("Corea exception [statusCode = {}, errorMessage = {}, cause = {}]", e.getHttpStatus(), e.getMessage(),e.getCause());
+        log.debug("Corea exception [statusCode = {}, errorMessage = {}, cause = {}]", e.getHttpStatus(), e.getMessage(), e.getCause());
         return ResponseEntity.status(e.getHttpStatus())
                 .body(new ErrorResponse(e.getMessage()));
     }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(final Exception e) {
-        log.debug("Server exception [errorMessage = {}, cause = {}]", e.getMessage(),e.getCause());
+        log.debug("Server exception [errorMessage = {}, cause = {}]", e.getMessage(), e.getCause());
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(e.getMessage()));
     }

--- a/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
+++ b/backend/src/main/java/corea/exception/ExceptionResponseHandler.java
@@ -1,0 +1,24 @@
+package corea.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class ExceptionResponseHandler {
+
+    @ExceptionHandler(CoreaException.class)
+    public ResponseEntity<ErrorResponse> handleCoreaException(final CoreaException e) {
+        log.debug("Reaction Game exception [statusCode = {}, errorMessage = {}, cause = {}]", e.getHttpStatus(), e.getMessage(),e.getCause());
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(new ErrorResponse(e.getMessage()));
+    }
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(final Exception e) {
+        log.debug("Server exception [errorMessage = {}, cause = {}]", e.getMessage(),e.getCause());
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse(e.getMessage()));
+    }
+}

--- a/backend/src/main/java/corea/exception/ExceptionType.java
+++ b/backend/src/main/java/corea/exception/ExceptionType.java
@@ -3,6 +3,9 @@ package corea.exception;
 import org.springframework.http.HttpStatus;
 
 public enum ExceptionType {
+
+    NOT_FOUND_ERROR(HttpStatus.NOT_FOUND,"해당하는 값이 없습니다."),
+    ALREADY_APPLY(HttpStatus.BAD_REQUEST,"해당 방에 이미 참여했습니다"),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버에 문제가 발생했습니다.");
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/corea/exception/ExceptionType.java
+++ b/backend/src/main/java/corea/exception/ExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionType {
 
     NOT_FOUND_ERROR(HttpStatus.NOT_FOUND,"해당하는 값이 없습니다."),
+    AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED,"인증에 실패했습니다."),
     ALREADY_APPLY(HttpStatus.BAD_REQUEST,"해당 방에 이미 참여했습니다"),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버에 문제가 발생했습니다.");
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/corea/matching/controller/ParticipateController.java
+++ b/backend/src/main/java/corea/matching/controller/ParticipateController.java
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/participate")
 @RequiredArgsConstructor
-public class ParticipateController {
+public class ParticipateController implements ParticipationControllerSpecification {
     private final ParticipationService participationService;
 
     @PostMapping("/{id}")
-    public ResponseEntity<Void> participate(@PathVariable final long id, @LoginUser AuthInfo authInfo) {
+    public ResponseEntity<Void> participate(@PathVariable long id, @LoginUser AuthInfo authInfo) {
         participationService.participate(new ParticipationRequest(id,authInfo.getId()));
         return ResponseEntity.ok()
                 .build();

--- a/backend/src/main/java/corea/matching/controller/ParticipateController.java
+++ b/backend/src/main/java/corea/matching/controller/ParticipateController.java
@@ -15,11 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/participate")
 @RequiredArgsConstructor
 public class ParticipateController implements ParticipationControllerSpecification {
+
     private final ParticipationService participationService;
 
     @PostMapping("/{id}")
     public ResponseEntity<Void> participate(@PathVariable long id, @LoginUser AuthInfo authInfo) {
-        participationService.participate(new ParticipationRequest(id,authInfo.getId()));
+        participationService.participate(new ParticipationRequest(id, authInfo.getId()));
         return ResponseEntity.ok()
                 .build();
     }

--- a/backend/src/main/java/corea/matching/controller/ParticipateController.java
+++ b/backend/src/main/java/corea/matching/controller/ParticipateController.java
@@ -1,0 +1,26 @@
+package corea.matching.controller;
+
+import corea.auth.annotation.LoginUser;
+import corea.auth.domain.AuthInfo;
+import corea.matching.dto.ParticipationRequest;
+import corea.matching.service.ParticipationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/participate")
+@RequiredArgsConstructor
+public class ParticipateController {
+    private final ParticipationService participationService;
+
+    @PostMapping("/{id}")
+    public ResponseEntity<Void> participate(@PathVariable final long id, @LoginUser AuthInfo authInfo) {
+        participationService.participate(new ParticipationRequest(id,authInfo.getId()));
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/backend/src/main/java/corea/matching/controller/ParticipationControllerSpecification.java
+++ b/backend/src/main/java/corea/matching/controller/ParticipationControllerSpecification.java
@@ -1,0 +1,24 @@
+package corea.matching.controller;
+
+import corea.auth.domain.AuthInfo;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+
+public interface ParticipationControllerSpecification {
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "해당하는 방이 없는 경우", value = """
+                    {
+                        "message": "1에 해당하는 방 없습니다."
+                    }
+                    """)
+                    })),
+            }
+    )
+    ResponseEntity<Void> participate(long id, AuthInfo authInfo);
+}

--- a/backend/src/main/java/corea/matching/repository/ParticipationRepository.java
+++ b/backend/src/main/java/corea/matching/repository/ParticipationRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
+
     List<Participation> findAllByRoomId(long roomId);
+
     boolean existsByRoomIdAndMemberId(long roomId, long memberId);
 }

--- a/backend/src/main/java/corea/matching/repository/ParticipationRepository.java
+++ b/backend/src/main/java/corea/matching/repository/ParticipationRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     List<Participation> findAllByRoomId(long roomId);
+    boolean existsByRoomIdAndMemberId(long roomId, long memberId);
 }

--- a/backend/src/main/java/corea/matching/service/ParticipationService.java
+++ b/backend/src/main/java/corea/matching/service/ParticipationService.java
@@ -1,5 +1,7 @@
 package corea.matching.service;
 
+import corea.exception.CoreaException;
+import corea.exception.ExceptionType;
 import corea.matching.domain.Participation;
 import corea.matching.dto.ParticipationRequest;
 import corea.matching.dto.ParticipationResponse;
@@ -28,10 +30,13 @@ public class ParticipationService {
 
     private void validateIdExist(final long roomId, final long memberId) {
         if (!roomRepository.existsById(roomId)) {
-            throw new IllegalArgumentException(String.format("해당 Id의 방이 없어 참여할 수 없습니다. 입력된 방 Id=%d", roomId));
+            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR,String.format("%d에 해당하는 방이 없습니다.",roomId));
         }
         if (!memberRepository.existsById(memberId)) {
-            throw new IllegalArgumentException(String.format("해당 Id의 멤버가 없어 방에 참여할 수 없습니다. 입력된 멤버 Id=%d", memberId));
+            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR,String.format("%d에 해당하는 멤버가 없습니다.",memberId));
+        }
+        if(participationRepository.existsByRoomIdAndMemberId(roomId, memberId)) {
+            throw new CoreaException(ExceptionType.ALREADY_APPLY);
         }
     }
 }

--- a/backend/src/main/java/corea/matching/service/ParticipationService.java
+++ b/backend/src/main/java/corea/matching/service/ParticipationService.java
@@ -5,8 +5,8 @@ import corea.exception.ExceptionType;
 import corea.matching.domain.Participation;
 import corea.matching.dto.ParticipationRequest;
 import corea.matching.dto.ParticipationResponse;
-import corea.member.repository.MemberRepository;
 import corea.matching.repository.ParticipationRepository;
+import corea.member.repository.MemberRepository;
 import corea.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,12 +30,12 @@ public class ParticipationService {
 
     private void validateIdExist(final long roomId, final long memberId) {
         if (!roomRepository.existsById(roomId)) {
-            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR,String.format("%d에 해당하는 방이 없습니다.",roomId));
+            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR, String.format("%d에 해당하는 방이 없습니다.", roomId));
         }
         if (!memberRepository.existsById(memberId)) {
-            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR,String.format("%d에 해당하는 멤버가 없습니다.",memberId));
+            throw new CoreaException(ExceptionType.NOT_FOUND_ERROR, String.format("%d에 해당하는 멤버가 없습니다.", memberId));
         }
-        if(participationRepository.existsByRoomIdAndMemberId(roomId, memberId)) {
+        if (participationRepository.existsByRoomIdAndMemberId(roomId, memberId)) {
             throw new CoreaException(ExceptionType.ALREADY_APPLY);
         }
     }

--- a/backend/src/main/java/corea/room/controller/RoomController.java
+++ b/backend/src/main/java/corea/room/controller/RoomController.java
@@ -5,7 +5,10 @@ import corea.room.dto.RoomResponses;
 import corea.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rooms")
@@ -14,14 +17,11 @@ public class RoomController {
 
     private final RoomService roomService;
 
-
     @GetMapping("/{id}")
     public ResponseEntity<RoomResponse> room(@PathVariable final long id) {
         final RoomResponse response = roomService.findOne(id);
         return ResponseEntity.ok(response);
     }
-
-
 
     @GetMapping
     public ResponseEntity<RoomResponses> rooms() {

--- a/backend/src/main/java/corea/room/controller/RoomController.java
+++ b/backend/src/main/java/corea/room/controller/RoomController.java
@@ -5,23 +5,25 @@ import corea.room.dto.RoomResponses;
 import corea.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/rooms")
 @RequiredArgsConstructor
 public class RoomController {
 
     private final RoomService roomService;
 
-    @GetMapping("/rooms/{id}")
+
+    @GetMapping("/{id}")
     public ResponseEntity<RoomResponse> room(@PathVariable final long id) {
         final RoomResponse response = roomService.findOne(id);
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/rooms")
+
+
+    @GetMapping
     public ResponseEntity<RoomResponses> rooms() {
         final RoomResponses response = roomService.findAll();
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/corea/room/domain/Room.java
+++ b/backend/src/main/java/corea/room/domain/Room.java
@@ -40,6 +40,7 @@ public class Room {
     private int limitedParticipantsSize;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id",foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member manager;
 
     private LocalDateTime recruitmentDeadline;

--- a/backend/src/main/java/corea/room/dto/RoomResponse.java
+++ b/backend/src/main/java/corea/room/dto/RoomResponse.java
@@ -24,7 +24,7 @@ public record RoomResponse(
         return new RoomResponse(
                 room.getId(), room.getTitle(), room.getContent(), room.getManager().getEmail(),
                 room.getRepositoryLink(), room.getThumbnailLink(), room.getMatchingSize(), List.of(room.getKeyword()),
-                room.getCurrentParticipantsSize(),room.getLimitedParticipantsSize(),room.getRecruitmentDeadline(),room.getReviewDeadline()
-                );
+                room.getCurrentParticipantsSize(), room.getLimitedParticipantsSize(), room.getRecruitmentDeadline(), room.getReviewDeadline()
+        );
     }
 }

--- a/backend/src/main/java/corea/room/dto/RoomResponse.java
+++ b/backend/src/main/java/corea/room/dto/RoomResponse.java
@@ -20,8 +20,11 @@ public record RoomResponse(
         LocalDateTime reviewDeadline
 ) {
 
-    //TODO 해당 객체를 사용한다면 반영
-    public static RoomResponse of(final Room room, final String author) {
-        return null;
+    public static RoomResponse of(final Room room) {
+        return new RoomResponse(
+                room.getId(), room.getTitle(), room.getContent(), room.getManager().getEmail(),
+                room.getRepositoryLink(), room.getThumbnailLink(), room.getMatchingSize(), List.of(room.getKeyword()),
+                room.getCurrentParticipantsSize(),room.getLimitedParticipantsSize(),room.getRecruitmentDeadline(),room.getReviewDeadline()
+                );
     }
 }

--- a/backend/src/main/java/corea/room/service/RoomService.java
+++ b/backend/src/main/java/corea/room/service/RoomService.java
@@ -1,6 +1,5 @@
 package corea.room.service;
 
-import corea.member.domain.Member;
 import corea.room.domain.Room;
 import corea.room.dto.RoomCreateRequest;
 import corea.room.dto.RoomResponse;
@@ -42,15 +41,8 @@ public class RoomService {
                 .collect(collectingAndThen(toList(), RoomResponses::new));
     }
 
-    //TODO 해당 객체를 사용한다면 반영
     private RoomResponse toRoomResponse(final Room room) {
-        final Member member = null;
-        return RoomResponse.of(room, member.getEmail());
-    }
-
-    private Member getMember(final long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException(String.format("해당 Id의 멤버가 없습니다. 입력된 Id=%d", memberId)));
+        return RoomResponse.of(room);
     }
 
     private Room getRoom(final long roomId) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,22 @@ spring:
       path: /h2-console
   datasource:
     url: jdbc:h2:mem:database
+
+springdoc:
+  swagger-ui:
+    groups-order: DESC
+    tags-sorter: alpha
+    operations-sorter: method
+    disable-swagger-default-url: true
+    display-request-duration: true
+    defaultModelsExpandDepth: 2
+    defaultModelExpandDepth: 2
+  api-docs:
+    path: /api-docs
+  show-actuator: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  writer-with-default-pretty-printer: true
+  model-and-view-allowed: true
+  paths-to-match:
+    - /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
   datasource:
     url: jdbc:h2:mem:database
 
+logging:
+  level:
+    root: INFO
+    corea: DEBUG
+
 springdoc:
   swagger-ui:
     groups-order: DESC

--- a/backend/src/test/java/config/ControllerTest.java
+++ b/backend/src/test/java/config/ControllerTest.java
@@ -1,0 +1,18 @@
+package config;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Sql(value = {"/clear.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestExecutionListeners(
+        value = {TestExecutionListener.class},
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
+public @interface ControllerTest {
+}

--- a/backend/src/test/java/config/TestExecutionListener.java
+++ b/backend/src/test/java/config/TestExecutionListener.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class TestExecutionListener extends AbstractTestExecutionListener {
+
     @Override
     public void beforeTestClass(final TestContext testContext) {
         RestAssured.port = Optional.ofNullable(testContext.getApplicationContext()

--- a/backend/src/test/java/config/TestExecutionListener.java
+++ b/backend/src/test/java/config/TestExecutionListener.java
@@ -1,0 +1,29 @@
+package config;
+
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.config.LogConfig;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public class TestExecutionListener extends AbstractTestExecutionListener {
+    @Override
+    public void beforeTestClass(final TestContext testContext) {
+        RestAssured.port = Optional.ofNullable(testContext.getApplicationContext()
+                        .getEnvironment()
+                        .getProperty("local.server.port", Integer.class))
+                .orElseThrow(() -> new IllegalStateException("localServerPort는 null일 수 없습니다."));
+
+        RestAssured.config = RestAssured.config()
+                .logConfig(LogConfig.logConfig()
+                        .enableLoggingOfRequestAndResponseIfValidationFails(LogDetail.ALL)
+                        .enablePrettyPrinting(true))
+                .encoderConfig(EncoderConfig.encoderConfig()
+                        .defaultCharsetForContentType(StandardCharsets.UTF_8.name(), ContentType.ANY));
+    }
+}

--- a/backend/src/test/java/corea/fixture/MemberFixture.java
+++ b/backend/src/test/java/corea/fixture/MemberFixture.java
@@ -1,0 +1,26 @@
+package corea.fixture;
+
+import corea.member.domain.Member;
+
+public class MemberFixture {
+    public static Member MEMBER_DOMAIN() {
+        return new Member(
+                "youngsu5582",
+                "https://avatars.githubusercontent.com/u/98307410?v=4",
+                null,
+                "youngsu5582@gmail.com",
+                false,
+                36.5f
+        );
+    }
+    public static Member MEMBER_MANAGER(){
+        return new Member(
+                "joyson5582",
+                "https://avatars.githubusercontent.com/u/98307410?v=4",
+                null,
+                "joyson5582@gmail.com",
+                false,
+                36.5f
+        );
+    }
+}

--- a/backend/src/test/java/corea/fixture/MemberFixture.java
+++ b/backend/src/test/java/corea/fixture/MemberFixture.java
@@ -3,6 +3,7 @@ package corea.fixture;
 import corea.member.domain.Member;
 
 public class MemberFixture {
+
     public static Member MEMBER_DOMAIN() {
         return new Member(
                 "youngsu5582",
@@ -13,7 +14,8 @@ public class MemberFixture {
                 36.5f
         );
     }
-    public static Member MEMBER_MANAGER(){
+
+    public static Member MEMBER_MANAGER() {
         return new Member(
                 "joyson5582",
                 "https://avatars.githubusercontent.com/u/98307410?v=4",

--- a/backend/src/test/java/corea/fixture/RoomFixture.java
+++ b/backend/src/test/java/corea/fixture/RoomFixture.java
@@ -1,0 +1,25 @@
+package corea.fixture;
+
+import corea.member.domain.Member;
+import corea.room.domain.Room;
+
+import java.time.LocalDateTime;
+
+public class RoomFixture {
+    public static Room ROOM_DOMAIN(final Member member) {
+        return new Room(
+                "자바 레이싱 카 - MVC",
+                "MVC 패턴을 아시나요?",
+                4,
+                "https://github.com/example/java-racingcar",
+                "https://gongu.copyright.or.kr/gongu/wrt/cmmn/wrtFileImageView.do?wrtSn=13301655&filePath=L2Rpc2sxL25ld2RhdGEvMjAyMS8yMS9DTFMxMDAwNC8xMzMwMTY1NV9XUlRfMjFfQ0xTMTAwMDRfMjAyMTEyMTNfMQ==&thumbAt=Y&thumbSe=b_tbumb&wrtTy=10004",
+                "TDD,클린코드,자바",
+                17,
+                30,
+                member,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+                        .plusDays(14)
+        );
+    }
+}

--- a/backend/src/test/java/corea/fixture/RoomFixture.java
+++ b/backend/src/test/java/corea/fixture/RoomFixture.java
@@ -6,6 +6,7 @@ import corea.room.domain.Room;
 import java.time.LocalDateTime;
 
 public class RoomFixture {
+
     public static Room ROOM_DOMAIN(final Member member) {
         return new Room(
                 "자바 레이싱 카 - MVC",

--- a/backend/src/test/java/corea/matching/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/corea/matching/controller/ParticipateControllerTest.java
@@ -29,7 +29,7 @@ class ParticipateControllerTest {
 
         Member member = memberRepository.save(MemberFixture.MEMBER_DOMAIN());
         //@formatter:off
-        RestAssured.given().header(new Header("Authorization",member.getEmail())).contentType(ContentType.JSON)
+        RestAssured.given().header(new Header("Authorization", member.getEmail())).contentType(ContentType.JSON)
                 .when().post("/participate/"+room.getId())
                 .then().assertThat().statusCode(200);
         //@formatter:on

--- a/backend/src/test/java/corea/matching/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/corea/matching/controller/ParticipateControllerTest.java
@@ -1,0 +1,37 @@
+package corea.matching.controller;
+
+import config.ControllerTest;
+import corea.fixture.MemberFixture;
+import corea.fixture.RoomFixture;
+import corea.member.domain.Member;
+import corea.member.repository.MemberRepository;
+import corea.room.domain.Room;
+import corea.room.repository.RoomRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ControllerTest
+class ParticipateControllerTest {
+    @Autowired
+    RoomRepository roomRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("사용자가 방에 참여한다.")
+    void participate() {
+        Member manager = memberRepository.save(MemberFixture.MEMBER_MANAGER());
+        Room room = roomRepository.save(RoomFixture.ROOM_DOMAIN(manager));
+
+        Member member = memberRepository.save(MemberFixture.MEMBER_DOMAIN());
+        //@formatter:off
+        RestAssured.given().header(new Header("Authorization",member.getEmail())).contentType(ContentType.JSON)
+                .when().post("/participate/"+room.getId())
+                .then().assertThat().statusCode(200);
+        //@formatter:on
+    }
+}

--- a/backend/src/test/java/corea/matching/service/ParticipationServiceTest.java
+++ b/backend/src/test/java/corea/matching/service/ParticipationServiceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 @ServiceTest
 class ParticipationServiceTest {
+
     @Autowired
     private ParticipationService sut;
 

--- a/backend/src/test/java/corea/matching/service/ParticipationServiceTest.java
+++ b/backend/src/test/java/corea/matching/service/ParticipationServiceTest.java
@@ -1,0 +1,68 @@
+package corea.matching.service;
+
+import config.ServiceTest;
+import corea.exception.CoreaException;
+import corea.fixture.MemberFixture;
+import corea.fixture.RoomFixture;
+import corea.matching.dto.ParticipationRequest;
+import corea.member.domain.Member;
+import corea.member.repository.MemberRepository;
+import corea.room.domain.Room;
+import corea.room.repository.RoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ServiceTest
+class ParticipationServiceTest {
+    @Autowired
+    private ParticipationService sut;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버가 방에 참여한다.")
+    void participate() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_DOMAIN());
+        Room room = roomRepository.save(RoomFixture.ROOM_DOMAIN(member));
+
+        assertThatCode(() -> sut.participate(new ParticipationRequest(room.getId(), member.getId())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("ID에 해당하는 방이 없으면 예외를 발생한다.")
+    void participate_throw_exception_when_roomId_not_exist() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_DOMAIN());
+
+        assertThatCode(() -> sut.participate(new ParticipationRequest(-1, member.getId())))
+                .isInstanceOf(CoreaException.class);
+    }
+
+    @Test
+    @DisplayName("ID에 해당하는 멤버가 없으면 예외를 발생한다.")
+    void participate_throw_exception_when_memberId_not_exist() {
+        Room room = roomRepository.save(RoomFixture.ROOM_DOMAIN(null));
+
+        assertThatCode(() -> sut.participate(new ParticipationRequest(room.getId(), -1)))
+                .isInstanceOf(CoreaException.class);
+    }
+
+    @Test
+    @DisplayName("이미 참여중인 방이면 예외를 발생한다.")
+    void participate_throw_exception_when_already_participate() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_DOMAIN());
+        Room room = roomRepository.save(RoomFixture.ROOM_DOMAIN(member));
+
+        sut.participate(new ParticipationRequest(room.getId(), member.getId()));
+
+        assertThatCode(() -> sut.participate(new ParticipationRequest(room.getId(), member.getId())))
+                .isInstanceOf(CoreaException.class);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[FE] feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #32 

## ✨ PR 세부 내용

방 생성하는 기능에 대해 구현했습니다.
추가로

- 로그인한 값을 가져오는 `LoginMemberArgumentResolver`, 로그인한 정보 `AuthInfo`
- 에러 응답을 담당하는 `ExceptionResponseHandler`
- 커스텀 어노테이션 `ControllerTest,ServiceTest` + 사전 작업하는 `TestExecutionListener`

Enum 부분 및 문서화 관련에서 기존에 제가 하던 방식대로 했는데

해당 부분들에 대해 자세히 얘기해봐도 좋을 거 같슴다.
( 처음이라 조율 해나가야 할 거 같음 )

[참고 링크](https://github.com/CollaBu/pennyway-was/blob/dev/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthCheckApi.java)

<img width="634" alt="image" src="https://github.com/user-attachments/assets/eb4c06db-a450-4e0c-b2fc-ed0659f67a3e">

에러 문서를 이렇게 자세하게 작성할 수도 있는데 해당 부분도 정해도 괜찮을 거 같습니다.

<img width="634" alt="image" src="https://github.com/user-attachments/assets/87e28b9e-0de6-4c13-84cc-56346afba247">

( 사진 처럼 가능 )