### PR TITLE
[FE] feat: 공통 Label 컴포넌트 추가(#65)

### DIFF
--- a/frontend/src/components/common/label/Label.stories.tsx
+++ b/frontend/src/components/common/label/Label.stories.tsx
@@ -1,0 +1,48 @@
+import Label from "./Label";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "common/Label",
+  component: Label,
+  parameters: {
+    docs: {
+      description: {
+        component: "라벨 컴포넌트",
+      },
+    },
+  },
+  argTypes: {
+    type: {
+      description: "라벨 타입",
+      control: { type: "select" },
+      options: ["keyword", "open", "close"],
+    },
+    text: {
+      description: "라벨 텍스트 (키워드 타입에만 적용)",
+      control: { type: "text" },
+    },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Keyword: Story = {
+  args: {
+    type: "keyword",
+    text: "FRONTEND",
+  },
+};
+
+export const Open: Story = {
+  args: {
+    type: "open",
+  },
+};
+
+export const Close: Story = {
+  args: {
+    type: "close",
+  },
+};

--- a/frontend/src/components/common/label/Label.style.ts
+++ b/frontend/src/components/common/label/Label.style.ts
@@ -1,0 +1,39 @@
+import { LabelType } from "./Label";
+import styled, { css } from "styled-components";
+
+interface LabelWrapperProps {
+  type: LabelType;
+}
+
+export const LabelWrapper = styled.div<LabelWrapperProps>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0.2rem 0.6rem;
+
+  font: ${({ theme }) => theme.TEXT.semiSmall};
+  color: ${({ theme }) => theme.COLOR.black};
+
+  border-radius: 15px;
+
+  ${({ type, theme }) => {
+    switch (type) {
+      case "keyword":
+        return css`
+          background-color: ${theme.COLOR.white};
+          border: 2px solid ${theme.COLOR.grey2};
+        `;
+      case "open":
+        return css`
+          color: ${theme.COLOR.black};
+          background-color: ${theme.COLOR.primary1};
+        `;
+      case "close":
+        return css`
+          color: ${theme.COLOR.white};
+          background-color: ${theme.COLOR.primary2};
+        `;
+    }
+  }}
+`;

--- a/frontend/src/components/common/label/Label.style.ts
+++ b/frontend/src/components/common/label/Label.style.ts
@@ -6,7 +6,7 @@ interface LabelWrapperProps {
 }
 
 export const LabelWrapper = styled.div<LabelWrapperProps>`
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
 

--- a/frontend/src/components/common/label/Label.style.ts
+++ b/frontend/src/components/common/label/Label.style.ts
@@ -10,9 +10,10 @@ export const LabelWrapper = styled.div<LabelWrapperProps>`
   align-items: center;
   justify-content: center;
 
-  padding: 0.2rem 0.6rem;
+  width: fit-content;
+  padding: 0 0.4rem;
 
-  font: ${({ theme }) => theme.TEXT.semiSmall};
+  font: ${({ theme }) => theme.TEXT.xSmall};
   color: ${({ theme }) => theme.COLOR.black};
 
   border-radius: 15px;
@@ -28,11 +29,13 @@ export const LabelWrapper = styled.div<LabelWrapperProps>`
         return css`
           color: ${theme.COLOR.black};
           background-color: ${theme.COLOR.primary1};
+          border: 2px solid ${theme.COLOR.primary1};
         `;
       case "close":
         return css`
           color: ${theme.COLOR.white};
           background-color: ${theme.COLOR.primary2};
+          border: 2px solid ${theme.COLOR.primary2};
         `;
     }
   }}

--- a/frontend/src/components/common/label/Label.tsx
+++ b/frontend/src/components/common/label/Label.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import * as S from "@/components/common/label/Label.style";
+
+export type LabelType = "keyword" | "open" | "close";
+
+interface LabelProps {
+  text?: string;
+  type: LabelType;
+}
+
+const Label = ({ text, type }: LabelProps) => {
+  return (
+    <S.LabelWrapper type={type}>
+      {type === "keyword" && `#${text}`}
+      {type === "open" && "모집 중"}
+      {type === "close" && "모집 완료"}
+    </S.LabelWrapper>
+  );
+};
+
+export default Label;


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #65 

## ✨ PR 세부 내용

- Label 컴포넌트 생성 완료
- 인자로 type과 text(optional)를 받습니다.
  - type이 keyword일 땐 받은 text를 보여주고, open일 땐 모집 중, close일 땐 모집 완료가 나타납니다. 
- Label 컴포넌트 스토리북도 생성 완료


## 🖼️ 스크린샷 
<img src="https://github.com/user-attachments/assets/ceac99a7-39eb-402c-8389-fe317317c1db" width="150px"/>