### PR TITLE
Feat/#158: 피드백 카드 컴포넌트 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --check .",
     "dev": "webpack-dev-server --mode=development --open --hot --progress",
     "build": "webpack --mode=production  --progress",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "start": "webpack --mode=development  --progress",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/frontend/src/@types/NonEmptyArray.ts
+++ b/frontend/src/@types/NonEmptyArray.ts
@@ -1,0 +1,1 @@
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/frontend/src/@types/feedback.ts
+++ b/frontend/src/@types/feedback.ts
@@ -1,0 +1,18 @@
+import { NonEmptyArray } from "@/@types/NonEmptyArray";
+
+export interface FeedbackCardList {
+  readonly roomId: number;
+  readonly title: string;
+  readonly roomKeywords: NonEmptyArray<string>;
+  readonly isClosed: boolean;
+  readonly feedbackData: FeedbackCardData[];
+}
+
+export interface FeedbackCardData {
+  readonly feedbackId: number;
+  readonly profile: string;
+  readonly nickname: string;
+  readonly feedbackKeywords: NonEmptyArray<string>;
+  readonly feedbackText: string;
+  readonly evaluationPoint: 1 | 2 | 3 | 4 | 5;
+}

--- a/frontend/src/components/feedback/evaluationPointBar/EvaluationPointBar.tsx
+++ b/frontend/src/components/feedback/evaluationPointBar/EvaluationPointBar.tsx
@@ -14,14 +14,20 @@ const evaluationOptions: EvaluationOption[] = [
   { text: "나쁨", value: 1, icon: "bad" },
   { text: "아쉬움", value: 2, icon: "disappointing" },
   { text: "보통", value: 3, icon: "average" },
-  { text: "만족", value: 3, icon: "satisfied" },
-  { text: "매우 만족", value: 3, icon: "verySatisfied" },
+  { text: "만족", value: 4, icon: "satisfied" },
+  { text: "매우 만족", value: 5, icon: "verySatisfied" },
 ];
 
-const EvaluationPointBar = () => {
-  const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null);
+interface EvaluationPointBarProps {
+  initialOptionId?: number;
+  readonly?: boolean;
+}
+
+const EvaluationPointBar = ({ initialOptionId, readonly = false }: EvaluationPointBarProps) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<number | undefined>(initialOptionId);
 
   const handleRadioChange = (id: number) => {
+    if (readonly) return;
     setSelectedOptionId(id);
   };
 

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.stories.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.stories.tsx
@@ -43,15 +43,11 @@ export const Default: Story = {
     feedbackId: 1,
     profile: "https://avatars.githubusercontent.com/u/63334368?v=4",
     nickname: "chlwlstlf",
-    feedbackKeywords: [
-      "잘하고 맛있어요.",
-      "오므라이스 김치볶음밥.",
-      "친절하고 꼼꼼하게 시술해줘요.",
-    ],
-    feedbackText: `나름 맛있게 해줘서 뿌듯했어요. 
-다음에도 좋은 시술 부탁드립니다. 근데 이집 햄버거가 맛있어요. 
-
-트리플베이컨더블빅치즈스페셜자이언트버거 먹으세요`,
+    feedbackKeywords: ["작업 속도", "PR 본문 메시지", "코드 관심사 분리"],
+    feedbackText: `작업 속도가 정말 빠르면서 평소 책을 많이 읽어서 그런지 PR 본문 메시지가 정말 알이 꽉꽉 찼어요.
+    
+    그리고 코드 관심사 분리라는 단어를 알고 있어서 대화하기 편했어요 ㅎㅎ.
+`,
     evaluationPoint: 1,
   },
 };

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.stories.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.stories.tsx
@@ -1,0 +1,57 @@
+import FeedbackCard from "./FeedbackCard";
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+const meta = {
+  title: "feedback/FeedbackCard",
+  component: FeedbackCard,
+  parameters: {
+    docs: {
+      description: {
+        score: "매너 온도 점수",
+      },
+    },
+  },
+  argTypes: {
+    feedbackId: {
+      description: "피드백 카드 id",
+    },
+    profile: {
+      description: "깃허브 프로필 이미지",
+    },
+    nickname: {
+      description: "닉네임",
+    },
+    feedbackKeywords: {
+      description: "피드백 키워드",
+    },
+    feedbackText: {
+      description: "피드백 세부 내용",
+    },
+    evaluationPoint: {
+      description: "피드백 점수",
+    },
+  },
+} satisfies Meta<typeof FeedbackCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    feedbackId: 1,
+    profile: "https://avatars.githubusercontent.com/u/63334368?v=4",
+    nickname: "chlwlstlf",
+    feedbackKeywords: [
+      "잘하고 맛있어요.",
+      "오므라이스 김치볶음밥.",
+      "친절하고 꼼꼼하게 시술해줘요.",
+    ],
+    feedbackText: `나름 맛있게 해줘서 뿌듯했어요. 
+다음에도 좋은 시술 부탁드립니다. 근데 이집 햄버거가 맛있어요. 
+
+트리플베이컨더블빅치즈스페셜자이언트버거 먹으세요`,
+    evaluationPoint: 1,
+  },
+};

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import media from "@/styles/media";
+
+export const FeedbackCardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  width: 40%;
+  min-width: 420px;
+  height: 500px;
+  padding: 1rem;
+
+  background: ${({ theme }) => theme.COLOR.grey0};
+  border-radius: 10px;
+
+  ${media.small`
+    width: 100%;
+  `}
+`;
+
+export const FeedbackKeywordContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+`;
+
+export const FeedbackTitle = styled.h3`
+  font-weight: bold;
+`;
+
+export const FeedbackKeyword = styled.div`
+  padding: 1rem;
+  font: ${({ theme }) => theme.TEXT.semiSmall};
+  background: ${({ theme }) => theme.COLOR.grey1};
+  border-radius: 5px;
+`;
+
+export const FeedbackDetailContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const FeedbackDetail = styled.p`
+  line-height: 20px;
+  white-space: break-spaces;
+`;

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
@@ -2,17 +2,20 @@ import styled from "styled-components";
 import media from "@/styles/media";
 
 export const FeedbackCardContainer = styled.div`
+  overflow-y: hidden;
   display: flex;
   flex-direction: column;
   gap: 2rem;
 
   width: 40%;
   min-width: 420px;
-  height: 500px;
+  height: 600px;
   padding: 1rem;
 
-  background: ${({ theme }) => theme.COLOR.grey0};
   border-radius: 10px;
+  box-shadow:
+    rgb(17 17 26 / 10%) 0 4px 16px,
+    rgb(17 17 26 / 5%) 0 8px 32px;
 
   ${media.small`
     width: 100%;
@@ -33,17 +36,25 @@ export const FeedbackTitle = styled.h3`
 export const FeedbackKeyword = styled.div`
   padding: 1rem;
   font: ${({ theme }) => theme.TEXT.semiSmall};
-  background: ${({ theme }) => theme.COLOR.grey1};
+  background: ${({ theme }) => theme.COLOR.grey0};
   border-radius: 5px;
 `;
 
 export const FeedbackDetailContainer = styled.div`
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  height: 200px;
 `;
 
 export const FeedbackDetail = styled.p`
-  line-height: 20px;
+  overflow: hidden;
+
+  height: 120px;
+
+  line-height: 1.2rem;
+  text-overflow: ellipsis;
   white-space: break-spaces;
 `;

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
@@ -23,6 +23,10 @@ export const FeedbackCardContainer = styled.div`
 `;
 
 export const FeedbackKeywordContainer = styled.div`
+  height: 130px;
+`;
+
+export const FeedbackKeywordWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
@@ -22,6 +22,12 @@ export const FeedbackCardContainer = styled.div`
   `}
 `;
 
+export const FeedbackScoreContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
 export const FeedbackKeywordContainer = styled.div`
   height: 130px;
 `;

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
@@ -1,0 +1,29 @@
+import * as S from "./FeedbackCard.style";
+import React from "react";
+import EvaluationPointBar from "@/components/feedback/evaluationPointBar/EvaluationPointBar";
+import { FeedbackCardData } from "@/@types/feedback";
+
+const FeedbackCard = (feedbackCardData: FeedbackCardData) => {
+  return (
+    <S.FeedbackCardContainer>
+      <S.FeedbackTitle>{feedbackCardData.nickname}</S.FeedbackTitle>
+      <EvaluationPointBar initialOptionId={feedbackCardData.evaluationPoint} readonly={true} />
+      <div>
+        <S.FeedbackTitle>피드백 키워드</S.FeedbackTitle>
+        <S.FeedbackKeywordContainer>
+          {feedbackCardData.feedbackKeywords.map((keyword) => (
+            <S.FeedbackKeyword>{keyword}</S.FeedbackKeyword>
+          ))}
+        </S.FeedbackKeywordContainer>
+      </div>
+      <S.FeedbackDetailContainer>
+        <S.FeedbackTitle>세부 피드백</S.FeedbackTitle>
+        <S.FeedbackDetail>
+          {feedbackCardData.feedbackText.length ? feedbackCardData.feedbackText : "없음"}
+        </S.FeedbackDetail>
+      </S.FeedbackDetailContainer>
+    </S.FeedbackCardContainer>
+  );
+};
+
+export default FeedbackCard;

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
@@ -8,7 +8,10 @@ const FeedbackCard = (feedbackCardData: FeedbackCardData) => {
   return (
     <S.FeedbackCardContainer>
       <S.FeedbackTitle>{feedbackCardData.nickname}</S.FeedbackTitle>
-      <EvaluationPointBar initialOptionId={feedbackCardData.evaluationPoint} readonly={true} />
+      <S.FeedbackScoreContainer>
+        <S.FeedbackTitle>피드백 점수</S.FeedbackTitle>
+        <EvaluationPointBar initialOptionId={feedbackCardData.evaluationPoint} readonly={true} />
+      </S.FeedbackScoreContainer>
       <S.FeedbackKeywordContainer>
         <S.FeedbackTitle>피드백 키워드</S.FeedbackTitle>
         <S.FeedbackKeywordWrapper>

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
@@ -1,5 +1,6 @@
 import * as S from "./FeedbackCard.style";
 import React from "react";
+import Button from "@/components/common/button/Button";
 import EvaluationPointBar from "@/components/feedback/evaluationPointBar/EvaluationPointBar";
 import { FeedbackCardData } from "@/@types/feedback";
 
@@ -22,6 +23,7 @@ const FeedbackCard = (feedbackCardData: FeedbackCardData) => {
           {feedbackCardData.feedbackText.length ? feedbackCardData.feedbackText : "없음"}
         </S.FeedbackDetail>
       </S.FeedbackDetailContainer>
+      <Button size="large">자세히 보기</Button>
     </S.FeedbackCardContainer>
   );
 };

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.tsx
@@ -9,14 +9,14 @@ const FeedbackCard = (feedbackCardData: FeedbackCardData) => {
     <S.FeedbackCardContainer>
       <S.FeedbackTitle>{feedbackCardData.nickname}</S.FeedbackTitle>
       <EvaluationPointBar initialOptionId={feedbackCardData.evaluationPoint} readonly={true} />
-      <div>
+      <S.FeedbackKeywordContainer>
         <S.FeedbackTitle>피드백 키워드</S.FeedbackTitle>
-        <S.FeedbackKeywordContainer>
+        <S.FeedbackKeywordWrapper>
           {feedbackCardData.feedbackKeywords.map((keyword) => (
             <S.FeedbackKeyword>{keyword}</S.FeedbackKeyword>
           ))}
-        </S.FeedbackKeywordContainer>
-      </div>
+        </S.FeedbackKeywordWrapper>
+      </S.FeedbackKeywordContainer>
       <S.FeedbackDetailContainer>
         <S.FeedbackTitle>세부 피드백</S.FeedbackTitle>
         <S.FeedbackDetail>

--- a/frontend/src/components/shared/roomCardModal/RoomCardModalButton.tsx
+++ b/frontend/src/components/shared/roomCardModal/RoomCardModalButton.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import useMutateParticipateIn from "@/hooks/mutations/useMutateParticipateIn";
 import Button from "@/components/common/button/Button";
 import { RoomInfo } from "@/@types/roomInfo";


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #158 

## ✨ PR 세부 내용

- 평가 점수 컴포넌트 읽기 전용으로 가능하도록 변경
- 피드백 카드 컴포넌트 추가

<img width="444" alt="image" src="https://github.com/user-attachments/assets/aa04f882-1f7c-4fa9-ab81-ecdb00df8366">

색상같은 디자인이 마땅히 좋은것을 찾지 못해서 회색으로 했는데 더욱 깔끔할거 같은 디자인이 있다면 코멘트 부탁ㄷ려용

<!-- 수정/추가한 내용을 적어주세요. -->
