### PR TITLE
[FE] 방 상세 페이지 디자인 수정(#313)

### DIFF
--- a/frontend/src/components/common/button/Button.style.ts
+++ b/frontend/src/components/common/button/Button.style.ts
@@ -2,7 +2,7 @@ import { css, styled } from "styled-components";
 
 export const ButtonContainer = styled.button<{
   $variant: "primary" | "secondary" | "disable";
-  $size: "small" | "medium" | "large";
+  $size: "xSmall" | "small" | "medium" | "large";
 }>`
   display: flex;
   align-items: center;
@@ -32,7 +32,7 @@ const variantStyles = {
     background-color: ${({ theme }) => theme.COLOR.primary2};
   `,
   secondary: css`
-    background-color: ${({ theme }) => theme.COLOR.error};
+    background-color: ${({ theme }) => theme.COLOR.secondary};
   `,
   disable: css`
     background-color: ${({ theme }) => theme.COLOR.grey1};
@@ -40,22 +40,28 @@ const variantStyles = {
 };
 
 const sizeStyles = {
+  xSmall: css`
+    width: 90px;
+    padding: 0.1rem 0;
+    font: ${({ theme }) => theme.TEXT.small};
+    border-radius: 4px;
+  `,
   small: css`
     width: 120px;
     padding: 0.1rem 0;
     font: ${({ theme }) => theme.TEXT.small};
-    border-radius: 5px;
+    border-radius: 4px;
   `,
   medium: css`
     width: 200px;
     height: 40px;
     font: ${({ theme }) => theme.TEXT.medium};
-    border-radius: 5px;
+    border-radius: 4px;
   `,
   large: css`
     width: 100%;
     height: 40px;
     font: ${({ theme }) => theme.TEXT.medium};
-    border-radius: 5px;
+    border-radius: 4px;
   `,
 };

--- a/frontend/src/components/common/button/Button.style.ts
+++ b/frontend/src/components/common/button/Button.style.ts
@@ -1,7 +1,7 @@
 import { css, styled } from "styled-components";
 
 export const ButtonContainer = styled.button<{
-  $variant: "primary" | "secondary" | "disable";
+  $variant: "primary" | "secondary" | "disable" | "lightBlue";
   $size: "xSmall" | "small" | "medium" | "large";
 }>`
   display: flex;
@@ -33,6 +33,9 @@ const variantStyles = {
   `,
   secondary: css`
     background-color: ${({ theme }) => theme.COLOR.secondary};
+  `,
+  lightBlue: css`
+    background-color: ${({ theme }) => theme.COLOR.lightGrass};
   `,
   disable: css`
     background-color: ${({ theme }) => theme.COLOR.grey1};

--- a/frontend/src/components/common/button/Button.tsx
+++ b/frontend/src/components/common/button/Button.tsx
@@ -3,7 +3,7 @@ import * as S from "@/components/common/button/Button.style";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "disable";
-  size?: "small" | "medium" | "large";
+  size?: "xSmall" | "small" | "medium" | "large";
 }
 
 const Button = ({

--- a/frontend/src/components/common/button/Button.tsx
+++ b/frontend/src/components/common/button/Button.tsx
@@ -2,7 +2,7 @@ import { ButtonHTMLAttributes } from "react";
 import * as S from "@/components/common/button/Button.style";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "disable";
+  variant?: "primary" | "secondary" | "disable" | "lightBlue";
   size?: "xSmall" | "small" | "medium" | "large";
 }
 

--- a/frontend/src/components/common/iconRadioButton/IconRadioButton.style.ts
+++ b/frontend/src/components/common/iconRadioButton/IconRadioButton.style.ts
@@ -32,7 +32,7 @@ export const IconRadioButtonBox = styled.div<IconRadioButtonBoxProps>`
   background-color: "transparent";
   border: ${({ $color, $isSelected, theme }) =>
     $isSelected
-      ? `4px solid ${$color ? $color : theme.COLOR.primary3}`
+      ? `4px solid ${$color ? $color : theme.COLOR.primary2}`
       : `1px solid ${theme.COLOR.grey1}`};
   border-radius: 50%;
   box-shadow: 0 4px 4px rgb(0 0 0 / 10%);

--- a/frontend/src/components/common/iconRadioButton/IconRadioButton.style.ts
+++ b/frontend/src/components/common/iconRadioButton/IconRadioButton.style.ts
@@ -10,6 +10,7 @@ export const IconRadioButtonContainer = styled.label`
 
   display: flex;
   flex-direction: column;
+  gap: 0.6rem;
   align-items: center;
   justify-content: center;
 `;

--- a/frontend/src/components/common/label/Label.style.ts
+++ b/frontend/src/components/common/label/Label.style.ts
@@ -4,6 +4,7 @@ import styled, { css } from "styled-components";
 interface LabelWrapperProps {
   type: LabelType;
   $size?: LabelSize;
+  $backgroundColor?: string;
 }
 
 export const LabelWrapper = styled.div<LabelWrapperProps>`
@@ -12,19 +13,20 @@ export const LabelWrapper = styled.div<LabelWrapperProps>`
   justify-content: center;
 
   width: fit-content;
-  padding: 0 0.4rem;
+  height: fit-content;
+  padding: 0.4rem 1rem;
 
   font: ${(props) => props.$size && props.theme.TEXT[props.$size]};
   color: ${({ theme }) => theme.COLOR.black};
 
   border-radius: 15px;
 
-  ${({ type, theme }) => {
+  ${({ $backgroundColor, type, theme }) => {
     switch (type) {
       case "keyword":
         return css`
-          background-color: ${theme.COLOR.white};
-          border: 1px solid ${theme.COLOR.grey1};
+          background-color: ${$backgroundColor || theme.COLOR.white};
+          border: 1px solid ${theme.COLOR.grey0};
         `;
       case "open":
         return css`

--- a/frontend/src/components/common/label/Label.tsx
+++ b/frontend/src/components/common/label/Label.tsx
@@ -8,11 +8,12 @@ interface LabelProps {
   text?: string;
   type: LabelType;
   size?: LabelSize;
+  backgroundColor?: string;
 }
 
-const Label = ({ text, type, size = "xSmall" }: LabelProps) => {
+const Label = ({ text, type, size = "xSmall", backgroundColor }: LabelProps) => {
   return (
-    <S.LabelWrapper type={type} $size={size}>
+    <S.LabelWrapper type={type} $size={size} $backgroundColor={backgroundColor}>
       {type === "keyword" && `#${text}`}
       {type === "open" && "모집 중"}
       {type === "close" && "모집 완료"}

--- a/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
+++ b/frontend/src/components/feedback/feedbackCard/FeedbackCard.style.ts
@@ -14,7 +14,7 @@ export const FeedbackCardContainer = styled.div<{ $isTypeDevelop: boolean }>`
 
   border: 3px solid
     ${({ theme, $isTypeDevelop }) =>
-      $isTypeDevelop ? theme.COLOR.primary3 : theme.COLOR.secondary};
+      $isTypeDevelop ? theme.COLOR.primary2 : theme.COLOR.secondary};
   border-radius: 10px;
 
   ${media.small`

--- a/frontend/src/components/feedback/feedbackForm/FeedbackForm.style.ts
+++ b/frontend/src/components/feedback/feedbackForm/FeedbackForm.style.ts
@@ -31,3 +31,9 @@ export const ModalQuestion = styled.p<ModalQuestionProps>`
     }
   `}
 `;
+
+export const StyledTextarea = styled.p`
+  display: flex;
+  width: 100%;
+  font: ${({ theme }) => theme.TEXT.semiSmall};
+`;

--- a/frontend/src/components/feedback/feedbackForm/FeedbackForm.style.ts
+++ b/frontend/src/components/feedback/feedbackForm/FeedbackForm.style.ts
@@ -13,6 +13,7 @@ export const ItemContainer = styled.div`
 export const ModalQuestion = styled.p<ModalQuestionProps>`
   display: flex;
   flex-direction: row;
+  align-items: center;
 
   font: ${({ theme }) => theme.TEXT.small};
   font-weight: 600;
@@ -22,7 +23,9 @@ export const ModalQuestion = styled.p<ModalQuestionProps>`
     required &&
     `
     &::after {
-      content: "*";
+      content: "*필수입력";
+      font: ${theme.TEXT.semiSmall};
+      font-weight: 400;
       color: ${theme.COLOR.error};
       margin-left: 4px;
     }

--- a/frontend/src/components/feedback/feedbackForm/RevieweeFeedbackForm.tsx
+++ b/frontend/src/components/feedback/feedbackForm/RevieweeFeedbackForm.tsx
@@ -54,14 +54,17 @@ const RevieweeFeedbackForm = ({ formState, onChange, modalType }: RevieweeFeedba
 
       <S.ItemContainer>
         <S.ModalQuestion>추가적으로 하고 싶은 피드백이 있다면 남겨 주세요.</S.ModalQuestion>
-        <Textarea
-          rows={5}
-          maxLength={512}
-          placeholder="상대 리뷰이의 개발 역량 향상을 위해 피드백을 남겨주세요."
-          value={formState.feedbackText}
-          onChange={(e) => onChange("feedbackText", e.target.value)}
-          readOnly={modalType === "view"}
-        />
+        {modalType === "view" ? (
+          <S.StyledTextarea>{formState.feedbackText}</S.StyledTextarea>
+        ) : (
+          <Textarea
+            rows={5}
+            maxLength={512}
+            placeholder="상대 리뷰이의 개발 역량 향상을 위해 피드백을 남겨주세요."
+            value={formState.feedbackText}
+            onChange={(e) => onChange("feedbackText", e.target.value)}
+          />
+        )}
       </S.ItemContainer>
 
       <S.ItemContainer>

--- a/frontend/src/components/feedback/feedbackForm/ReviewerFeedbackForm.tsx
+++ b/frontend/src/components/feedback/feedbackForm/ReviewerFeedbackForm.tsx
@@ -56,14 +56,17 @@ const ReviewerFeedbackForm = ({ formState, onChange, modalType }: ReviewerFeedba
 
       <S.ItemContainer>
         <S.ModalQuestion>추가적으로 하고 싶은 피드백이 있다면 남겨 주세요.</S.ModalQuestion>
-        <Textarea
-          rows={5}
-          maxLength={512}
-          placeholder="상대 리뷰어의 소프트 스킬 역량 향상을 위해 피드백을 남겨주세요."
-          value={formState.feedbackText}
-          onChange={(e) => onChange("feedbackText", e.target.value)}
-          readOnly={modalType === "view"}
-        />
+        {modalType === "view" ? (
+          <S.StyledTextarea>{formState.feedbackText}</S.StyledTextarea>
+        ) : (
+          <Textarea
+            rows={5}
+            maxLength={512}
+            placeholder="상대 리뷰어의 소프트 스킬 역량 향상을 위해 피드백을 남겨주세요."
+            value={formState.feedbackText}
+            onChange={(e) => onChange("feedbackText", e.target.value)}
+          />
+        )}
       </S.ItemContainer>
     </>
   );

--- a/frontend/src/components/feedback/feedbackForm/ReviewerFeedbackForm.tsx
+++ b/frontend/src/components/feedback/feedbackForm/ReviewerFeedbackForm.tsx
@@ -8,6 +8,7 @@ import {
   SOCIAL_GOOD_KEYWORD_OPTIONS,
   SOCIAL_NORMAL_KEYWORD_OPTIONS,
 } from "@/constants/feedback";
+import { theme } from "@/styles/theme";
 import { FeedbackModalType } from "@/utils/feedbackUtils";
 
 interface ReviewerFeedbackFormProps {
@@ -37,6 +38,7 @@ const ReviewerFeedbackForm = ({ formState, onChange, modalType }: ReviewerFeedba
           initialOptionId={formState.evaluationPoint}
           onChange={(value) => onChange("evaluationPoint", value)}
           readonly={modalType === "view"}
+          color={theme.COLOR.secondary}
         />
       </S.ItemContainer>
 
@@ -48,6 +50,7 @@ const ReviewerFeedbackForm = ({ formState, onChange, modalType }: ReviewerFeedba
           selectedEvaluationId={formState.evaluationPoint}
           readonly={modalType === "view"}
           options={getSocialKeywordOptions(formState.evaluationPoint)}
+          color={theme.COLOR.secondary}
         />
       </S.ItemContainer>
 

--- a/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.style.ts
+++ b/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.style.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 interface OptionButtonBoxProps {
   isSelected?: boolean;
+  color?: string;
 }
 
 export const OptionContainer = styled.div`
@@ -25,6 +26,6 @@ export const ButtonWrapper = styled.button<OptionButtonBoxProps>`
   border-radius: 18px;
   outline: ${(props) =>
     props.isSelected
-      ? `4px solid ${props.theme.COLOR.primary3}`
+      ? `4px solid ${props.color || props.theme.COLOR.primary3}`
       : `2px dashed ${props.theme.COLOR.grey1}`};
 `;

--- a/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.style.ts
+++ b/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.style.ts
@@ -26,6 +26,6 @@ export const ButtonWrapper = styled.button<OptionButtonBoxProps>`
   border-radius: 18px;
   outline: ${(props) =>
     props.isSelected
-      ? `4px solid ${props.color || props.theme.COLOR.primary3}`
+      ? `4px solid ${props.color || props.theme.COLOR.primary2}`
       : `2px dashed ${props.theme.COLOR.grey1}`};
 `;

--- a/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.tsx
+++ b/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.tsx
@@ -16,7 +16,7 @@ const KeywordOptionButton = ({
   readonly = false,
   onChange,
   options,
-  color = theme.COLOR.primary3,
+  color = theme.COLOR.primary2,
 }: OptionButtonProps) => {
   const [selectedOptions, setSelectedOptions] = useState<string[]>(initialOptions);
 

--- a/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.tsx
+++ b/frontend/src/components/feedback/keywordOptionButton/KeywordOptionButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import * as S from "@/components/feedback/keywordOptionButton/KeywordOptionButton.style";
+import { theme } from "@/styles/theme";
 
 interface OptionButtonProps {
   initialOptions?: string[];
@@ -7,6 +8,7 @@ interface OptionButtonProps {
   onChange?: (options: string[]) => void;
   selectedEvaluationId?: number;
   options: string[];
+  color?: string;
 }
 
 const KeywordOptionButton = ({
@@ -14,6 +16,7 @@ const KeywordOptionButton = ({
   readonly = false,
   onChange,
   options,
+  color = theme.COLOR.primary3,
 }: OptionButtonProps) => {
   const [selectedOptions, setSelectedOptions] = useState<string[]>(initialOptions);
 
@@ -39,6 +42,7 @@ const KeywordOptionButton = ({
           key={text}
           onClick={() => toggleOption(text)}
           isSelected={selectedOptions.includes(text)}
+          color={color}
         >
           {text}
         </S.ButtonWrapper>

--- a/frontend/src/components/feedback/revieweeFeedbackModal/RevieweeFeedbackModal.tsx
+++ b/frontend/src/components/feedback/revieweeFeedbackModal/RevieweeFeedbackModal.tsx
@@ -6,6 +6,7 @@ import RevieweeFeedbackForm from "@/components/feedback/feedbackForm/RevieweeFee
 import * as S from "@/components/feedback/revieweeFeedbackModal/RevieweeFeedbackModal.style";
 import { ReviewerInfo } from "@/@types/reviewer";
 import { RoomInfo } from "@/@types/roomInfo";
+import { theme } from "@/styles/theme";
 import { FeedbackModalType } from "@/utils/feedbackUtils";
 
 interface RevieweeFeedbackModalProps {
@@ -39,7 +40,13 @@ const RevieweeFeedbackModal = ({
         <S.ModalTitle>{roomInfo.title}</S.ModalTitle>
         <S.Keywords>
           {roomInfo.keywords.map((keyword) => (
-            <Label key={keyword} type="keyword" text={keyword} size="semiSmall" />
+            <Label
+              key={keyword}
+              type="keyword"
+              text={keyword}
+              size="semiSmall"
+              backgroundColor={theme.COLOR.grey0}
+            />
           ))}
         </S.Keywords>
 

--- a/frontend/src/components/feedback/reviewerFeedbackModal/ReviewerFeedbackModal.tsx
+++ b/frontend/src/components/feedback/reviewerFeedbackModal/ReviewerFeedbackModal.tsx
@@ -6,6 +6,7 @@ import ReviewerFeedbackForm from "@/components/feedback/feedbackForm/ReviewerFee
 import * as S from "@/components/feedback/reviewerFeedbackModal/ReviewerFeedbackModal.style";
 import { ReviewerInfo } from "@/@types/reviewer";
 import { RoomInfo } from "@/@types/roomInfo";
+import { theme } from "@/styles/theme";
 import { FeedbackModalType } from "@/utils/feedbackUtils";
 
 interface ReviewerFeedbackModalProps {
@@ -39,7 +40,13 @@ const ReviewerFeedbackModal = ({
         <S.ModalTitle>{roomInfo.title}</S.ModalTitle>
         <S.Keywords>
           {roomInfo.keywords.map((keyword) => (
-            <Label key={keyword} type="keyword" text={keyword} size="semiSmall" />
+            <Label
+              key={keyword}
+              type="keyword"
+              text={keyword}
+              size="semiSmall"
+              backgroundColor={theme.COLOR.grey0}
+            />
           ))}
         </S.Keywords>
 

--- a/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.style.ts
+++ b/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.style.ts
@@ -1,15 +1,21 @@
 import styled from "styled-components";
+import media from "@/styles/media";
 
 export const MyRevieweeContainer = styled.div`
+  width: 100%;
+
+  font: ${({ theme }) => theme.TEXT.small};
+  font-family: "Do Hyeon", sans-serif;
+
   border: 1px solid ${({ theme }) => theme.COLOR.grey1};
-  border-radius: 1rem;
+  border-radius: 8px;
 `;
 
 export const MyRevieweeWrapper = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 2rem;
+  padding: 0.5rem 1rem;
 
   &:not(:last-child) {
     border-bottom: 1px solid ${({ theme }) => theme.COLOR.grey1};
@@ -17,23 +23,24 @@ export const MyRevieweeWrapper = styled.div`
 `;
 
 export const MyRevieweeTitle = styled.span`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 200px;
+  font-weight: bold;
+  text-align: center;
 `;
 
 export const MyRevieweeContent = styled.span`
   display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
   align-items: center;
-
-  width: 200px;
+  justify-content: center;
+  text-align: center;
 `;
 
 export const PRLink = styled.a`
   cursor: pointer;
+
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
   text-decoration: underline;
   text-underline-offset: 0.3rem;
 
@@ -41,4 +48,16 @@ export const PRLink = styled.a`
     color: ${({ theme }) => theme.COLOR.primary2};
     text-decoration: underline;
   }
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
+
+export const IconWrapper = styled.span`
+  ${media.small`
+    display: none;
+`}
 `;

--- a/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.tsx
+++ b/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.tsx
@@ -91,7 +91,7 @@ const MyReviewee = ({ roomInfo }: MyReviewerProps) => {
                 <S.ButtonContainer>
                   <Button
                     size="xSmall"
-                    variant={reviewee.isReviewed ? "disable" : "secondary"}
+                    variant={reviewee.isReviewed ? "disable" : "lightBlue"}
                     disabled={reviewee.isReviewed}
                     onClick={() => handleReviewCompleteClick(reviewee.userId)}
                   >

--- a/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.tsx
+++ b/frontend/src/components/roomDetailPage/myReviewee/MyReviewee.tsx
@@ -80,28 +80,32 @@ const MyReviewee = ({ roomInfo }: MyReviewerProps) => {
 
               <S.MyRevieweeContent>
                 <S.PRLink href={reviewee.link}>
-                  <Icon kind="link" />
+                  <S.IconWrapper>
+                    <Icon kind="link" />
+                  </S.IconWrapper>
                   바로가기
                 </S.PRLink>
               </S.MyRevieweeContent>
 
               <S.MyRevieweeContent>
-                <Button
-                  size="small"
-                  variant={reviewee.isReviewed ? "disable" : "secondary"}
-                  disabled={reviewee.isReviewed}
-                  onClick={() => handleReviewCompleteClick(reviewee.userId)}
-                >
-                  {reviewee.isReviewed ? "코드리뷰 완료" : "코드리뷰 하기"}
-                </Button>
-                <Button
-                  size="small"
-                  onClick={() => handleOpenFeedbackModal(reviewee)}
-                  variant={reviewee.isReviewed ? "primary" : "disable"}
-                  disabled={!reviewee.isReviewed}
-                >
-                  {buttonText}
-                </Button>
+                <S.ButtonContainer>
+                  <Button
+                    size="xSmall"
+                    variant={reviewee.isReviewed ? "disable" : "secondary"}
+                    disabled={reviewee.isReviewed}
+                    onClick={() => handleReviewCompleteClick(reviewee.userId)}
+                  >
+                    코드리뷰 완료
+                  </Button>
+                  <Button
+                    size="xSmall"
+                    onClick={() => handleOpenFeedbackModal(reviewee)}
+                    variant={reviewee.isReviewed ? "primary" : "disable"}
+                    disabled={!reviewee.isReviewed}
+                  >
+                    {buttonText}
+                  </Button>
+                </S.ButtonContainer>
               </S.MyRevieweeContent>
             </S.MyRevieweeWrapper>
           );

--- a/frontend/src/components/roomDetailPage/myReviewer/MyReviewer.style.ts
+++ b/frontend/src/components/roomDetailPage/myReviewer/MyReviewer.style.ts
@@ -1,15 +1,22 @@
 import styled from "styled-components";
+import media from "@/styles/media";
+import { theme } from "@/styles/theme";
 
 export const MyReviewerContainer = styled.div`
+  width: 100%;
+
+  font: ${({ theme }) => theme.TEXT.small};
+  font-family: "Do Hyeon", sans-serif;
+
   border: 1px solid ${({ theme }) => theme.COLOR.grey1};
-  border-radius: 1rem;
+  border-radius: 8px;
 `;
 
 export const MyReviewerWrapper = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 2rem;
+  padding: 0.5rem 1rem;
 
   &:not(:last-child) {
     border-bottom: 1px solid ${({ theme }) => theme.COLOR.grey1};
@@ -17,23 +24,24 @@ export const MyReviewerWrapper = styled.div`
 `;
 
 export const MyReviewerTitle = styled.span`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 200px;
+  font-weight: bold;
+  text-align: center;
 `;
 
 export const MyReviewerContent = styled.span`
   display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
   align-items: center;
-
-  width: 200px;
+  justify-content: center;
+  text-align: center;
 `;
 
 export const PRLink = styled.a`
   cursor: pointer;
+
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
   text-decoration: underline;
   text-underline-offset: 0.3rem;
 
@@ -41,4 +49,10 @@ export const PRLink = styled.a`
     color: ${({ theme }) => theme.COLOR.primary2};
     text-decoration: underline;
   }
+`;
+
+export const IconWrapper = styled.span`
+  ${media.small`
+    display: none;
+`}
 `;

--- a/frontend/src/components/roomDetailPage/myReviewer/MyReviewer.tsx
+++ b/frontend/src/components/roomDetailPage/myReviewer/MyReviewer.tsx
@@ -73,16 +73,18 @@ const MyReviewer = ({ roomInfo }: MyReviewerProps) => {
               <S.MyReviewerContent>{reviewer.username}</S.MyReviewerContent>
               <S.MyReviewerContent>
                 <S.PRLink href={reviewer.link}>
-                  <Icon kind="link" />
+                  <S.IconWrapper>
+                    <Icon kind="link" />
+                  </S.IconWrapper>
                   바로가기
                 </S.PRLink>
               </S.MyReviewerContent>
 
               <S.MyReviewerContent>
                 <Button
-                  size="small"
+                  size="xSmall"
                   onClick={() => handleOpenFeedbackModal(reviewer)}
-                  variant={reviewer.isReviewed ? "primary" : "disable"}
+                  variant={reviewer.isReviewed ? "secondary" : "disable"}
                   disabled={!reviewer.isReviewed}
                 >
                   {buttonText}

--- a/frontend/src/components/roomDetailPage/roomInfoCard/RoomInfoCard.style.ts
+++ b/frontend/src/components/roomDetailPage/roomInfoCard/RoomInfoCard.style.ts
@@ -1,13 +1,13 @@
 import styled from "styled-components";
+import media from "@/styles/media";
 
 export const RoomInfoCardContainer = styled.div`
   display: flex;
 
   width: 100%;
-  padding-left: 2rem;
 
   border: 1px solid ${({ theme }) => theme.COLOR.grey1};
-  border-radius: 1rem;
+  border-radius: 8px;
   box-shadow: 0 4px 4px rgb(0 0 0 / 10%);
 `;
 
@@ -17,29 +17,41 @@ export const RoomInfoCardImg = styled.img`
 
   width: 15rem;
   height: 100%;
+  margin: 1rem;
 
   object-fit: scale-down;
+
+  ${media.small`
+    display: none;
+  `}
 `;
 
 export const RoomInfoCardContent = styled.div`
   display: flex;
   flex-direction: column;
 
-  width: calc(100% - 15rem);
+  width: 100%;
   height: 100%;
-  padding: 2rem;
+  padding: 2rem 1rem;
 `;
 
 export const RoomHeaderWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 
   margin-bottom: 1rem;
-  padding-bottom: 1rem;
+  padding-bottom: 0.5rem;
 
   border-bottom: 1px solid ${({ theme }) => theme.COLOR.grey1};
+
+  ${media.small`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  `}
 `;
 
 export const RoomTitle = styled.span`
@@ -49,6 +61,10 @@ export const RoomTitle = styled.span`
 
 export const RepositoryLink = styled.a`
   cursor: pointer;
+
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 
   font: ${({ theme }) => theme.TEXT.small};
   color: ${({ theme }) => theme.COLOR.black};
@@ -73,14 +89,24 @@ export const RoomContentBox = styled.div`
 `;
 
 export const RoomContentSmall = styled.span`
+  display: flex;
+  gap: 1rem;
   font: ${({ theme }) => theme.TEXT.small};
   color: ${({ theme }) => theme.COLOR.black};
+
+  ${media.small`
+    gap: 0.4rem;
+  `}
+`;
+
+export const StyledDday = styled.span`
+  color: ${({ theme }) => theme.COLOR.error};
 `;
 
 export const RoomTagBox = styled.div`
   display: flex;
-  flex-direction: row;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 `;
 
 export const RoomKeyword = styled.div`

--- a/frontend/src/components/roomDetailPage/roomInfoCard/RoomInfoCard.tsx
+++ b/frontend/src/components/roomDetailPage/roomInfoCard/RoomInfoCard.tsx
@@ -1,7 +1,9 @@
 import Icon from "@/components/common/icon/Icon";
+import Label from "@/components/common/label/Label";
 import * as S from "@/components/roomDetailPage/roomInfoCard/RoomInfoCard.style";
 import { RoomInfo } from "@/@types/roomInfo";
-import { formatDateTimeString } from "@/utils/dateFormatter";
+import { theme } from "@/styles/theme";
+import { formatDateTimeString, formatDday } from "@/utils/dateFormatter";
 
 const RoomInfoCard = ({ roomInfo }: { roomInfo: RoomInfo }) => {
   return (
@@ -18,10 +20,14 @@ const RoomInfoCard = ({ roomInfo }: { roomInfo: RoomInfo }) => {
 
         <S.RoomContentBox>
           <S.RoomTagBox>
-            {roomInfo.keywords.map((keyword, index) => (
-              <S.RoomKeyword key={keyword}>
-                <S.RoomContentSmall>#{keyword}</S.RoomContentSmall>
-              </S.RoomKeyword>
+            {roomInfo.keywords.map((keyword) => (
+              <Label
+                key={keyword}
+                type="keyword"
+                text={keyword}
+                size="small"
+                backgroundColor={theme.COLOR.primary1}
+              />
             ))}
           </S.RoomTagBox>
           <S.RoomContentSmall>{roomInfo.content}</S.RoomContentSmall>
@@ -41,11 +47,17 @@ const RoomInfoCard = ({ roomInfo }: { roomInfo: RoomInfo }) => {
           </S.RoomContentSmall>
           <S.RoomContentSmall>
             <Icon kind="calendar" />
-            모집 마감일: {formatDateTimeString(roomInfo.recruitmentDeadline)}
+            <div>
+              모집 마감일: {formatDateTimeString(roomInfo.recruitmentDeadline)}
+              <S.StyledDday> {formatDday(roomInfo.recruitmentDeadline)}</S.StyledDday>
+            </div>
           </S.RoomContentSmall>
           <S.RoomContentSmall>
             <Icon kind="calendar" />
-            리뷰 마감일: {formatDateTimeString(roomInfo.reviewDeadline)}
+            <div>
+              리뷰 마감일: {formatDateTimeString(roomInfo.reviewDeadline)}
+              <S.StyledDday> {formatDday(roomInfo.reviewDeadline)}</S.StyledDday>
+            </div>
           </S.RoomContentSmall>
         </S.RoomContentBox>
       </S.RoomInfoCardContent>

--- a/frontend/src/pages/roomDetail/RoomDetailPage.style.ts
+++ b/frontend/src/pages/roomDetail/RoomDetailPage.style.ts
@@ -1,12 +1,41 @@
 import styled from "styled-components";
+import media from "@/styles/media";
 
 export const Layout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 5rem;
+
+  ${media.small`
+    gap: 2rem;
+  `}
+`;
+
+export const FeedbackContainer = styled.div`
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+
+  ${media.small`
+    display: flex;
+    gap: 2rem;  
+    flex-direction: column;
+  `}
+`;
+
+export const FeedbackSection = styled.div`
+  width: 100%;
+
+  ${media.medium`
+    width: calc(50% - 1rem); 
+  `}
+
+  ${media.large`
+    width: calc(50% - 1rem); 
+  `}
 `;
 
 export const StyledDescription = styled.p`
   font: ${({ theme }) => theme.TEXT.small};
-  color: ${({ theme }) => theme.COLOR.grey2};
+  color: ${({ theme }) => theme.COLOR.grey3};
 `;

--- a/frontend/src/pages/roomDetail/RoomDetailPage.tsx
+++ b/frontend/src/pages/roomDetail/RoomDetailPage.tsx
@@ -23,17 +23,25 @@ const RoomDetailPage = () => {
         <RoomInfoCard roomInfo={roomInfo} />
       </ContentSection>
 
-      <ContentSection title="나를 리뷰해주는 분">
-        <S.StyledDescription>
-          리뷰어 피드백은 소프트 스킬 역량에 한해서 진행합니다.
-        </S.StyledDescription>
-        <MyReviewer roomInfo={roomInfo} />
-      </ContentSection>
+      <S.FeedbackContainer>
+        <S.FeedbackSection>
+          <ContentSection title="나를 리뷰해주는 분">
+            <S.StyledDescription>
+              리뷰어 피드백은 소프트 스킬 역량에 한해서 진행합니다.
+            </S.StyledDescription>
+            <MyReviewer roomInfo={roomInfo} />
+          </ContentSection>
+        </S.FeedbackSection>
 
-      <ContentSection title="내가 리뷰해야하는 분">
-        <S.StyledDescription>리뷰이 피드백은 개발 역량에 한해서 진행합니다.</S.StyledDescription>
-        <MyReviewee roomInfo={roomInfo} />
-      </ContentSection>
+        <S.FeedbackSection>
+          <ContentSection title="내가 리뷰해야하는 분">
+            <S.StyledDescription>
+              리뷰이 피드백은 개발 역량에 한해서 진행합니다.
+            </S.StyledDescription>
+            <MyReviewee roomInfo={roomInfo} />
+          </ContentSection>
+        </S.FeedbackSection>
+      </S.FeedbackContainer>
     </S.Layout>
   );
 };

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -209,12 +209,12 @@ const globalStyles = createGlobalStyle`
 
   ::-webkit-scrollbar-thumb {
     height: 30%;
-    background: rgb(132 174 225 / 70%);
+    background: rgb(198 198 198 / 70%);
     border-radius: 10px;
   }
 
   ::-webkit-scrollbar-track {
-    background: rgb(132 174 225 / 20%);
+    background: rgb(198 198 198 / 20%);
   }
 `;
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -12,6 +12,7 @@ const COLOR = {
   secondary: "#ffaaaf",
   lightGrass: "#D7E4D8",
   grass: "#00B707",
+  lightBlue: "#a2c4c9",
   error: "#FF3D45",
 };
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -12,7 +12,7 @@ const COLOR = {
   secondary: "#ffaaaf",
   lightGrass: "#D7E4D8",
   grass: "#00B707",
-  error: "FF3D45",
+  error: "#FF3D45",
 };
 
 const TEXT = {

--- a/frontend/src/utils/dateFormatter.ts
+++ b/frontend/src/utils/dateFormatter.ts
@@ -18,7 +18,7 @@ export const formatDeadlineString = (dateString: string): string => {
 // 일반 날짜 시간 포맷 함수
 export const formatDateTimeString = (dateString: string): string => {
   const { year, month, day, hours, minutes } = formatDate(dateString);
-  return `${year}년 ${month}월 ${day}일 ${hours}시 ${minutes}분`;
+  return `${year.slice(2)}-${month}-${day} ${hours}시 ${minutes}분`;
 };
 
 // 디데이 포맷 함수

--- a/frontend/src/utils/dateFormatter.ts
+++ b/frontend/src/utils/dateFormatter.ts
@@ -20,3 +20,23 @@ export const formatDateTimeString = (dateString: string): string => {
   const { year, month, day, hours, minutes } = formatDate(dateString);
   return `${year}년 ${month}월 ${day}일 ${hours}시 ${minutes}분`;
 };
+
+// 디데이 포맷 함수
+export const formatDday = (dateString: string): string => {
+  const targetDate = new Date(dateString);
+  const today = new Date();
+
+  today.setHours(0, 0, 0, 0);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const timeDiff = targetDate.getTime() - today.getTime();
+  const dayDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+
+  if (dayDiff > 0) {
+    return `D-${dayDiff}`;
+  }
+  if (dayDiff === 0) {
+    return "D-Day";
+  }
+  return "종료됨";
+};


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #313 

## ✨ PR 세부 내용
- 방 상세 페이지 내부 컴포넌트들의 css 디테일을 수정했습니다.
- 방 상세 페이지 반응형 디자인을 수정했습니다.
  - 모바일 사이즈에서는 방 상세 정보의 이미지가 보이지 않도록 수정
  - 모바일 사이즈에서는 피드백 표가 세로 정렬되도록 수정
  
<img src="https://github.com/user-attachments/assets/c1903437-9365-475c-ba52-e6c93d279e8f" width="600px"/>
<img src="https://github.com/user-attachments/assets/fa73d384-9364-443d-970c-9a37df05fe02" width="200px"/>

- 모달 내부의 색도 수정했습니다.(보더색은 이상해서 적용하지 않았어요)
<img src="https://github.com/user-attachments/assets/5726c8b9-aaae-4a7e-9033-9fe9c8c97bb5" width="300px"/>
<img src="https://github.com/user-attachments/assets/9fa73cba-ca71-4f82-89b4-6562059d3dff" width="300px"/>



<!-- 수정/추가한 내용을 적어주세요. -->
